### PR TITLE
Update AsphyxiaUI/Modules/Extras/CombatText.lua

### DIFF
--- a/AsphyxiaUI/Modules/Extras/CombatText.lua
+++ b/AsphyxiaUI/Modules/Extras/CombatText.lua
@@ -819,7 +819,7 @@ if C.combattext.damage then
 				else
 					msg = ""
 				end
-				xCT3:AddMessage(ACTION_SPELL_INTERRUPTS..": "..effect..msg, unpack(color))
+				xCT3:AddMessage(ACTION_SPELL_INTERRUPT..": "..effect..msg, unpack(color))
 			elseif eventType == "PARTY_KILL" and C.combattext.killingblow then
 				local tname = select(9, ...)
 				xCT3:AddMessage(ACTION_PARTY_KILL..": "..tname, 0.2, 1, 0.2)


### PR DESCRIPTION
When fixed this typo left the S which kept giving errors for certain
classes. Tested with a'lot of diff people and classes no more errors.
