### PR TITLE
Skada theme broken?

### DIFF
--- a/AsphyxiaUI/Modules/Skins/Addons/load_addons.xml
+++ b/AsphyxiaUI/Modules/Skins/Addons/load_addons.xml
@@ -5,4 +5,5 @@
 	<Script file="Omen.lua" />
 	<Script file="TinyDPS.lua" />
 	<Script file="Coolline.lua" />
+	<Script file="Skada.lua" />
 </Ui>

--- a/AsphyxiaUI_Config/Config/Config.lua
+++ b/AsphyxiaUI_Config/Config/Config.lua
@@ -16,6 +16,7 @@ C["addonskins"] = {
 	["dbm"] = true,
 	["omen"] = true,
 	["tinydps"] = true,
+	["skada"] = true,
 }
 
 C["global"] = {


### PR DESCRIPTION
Noticed that I wasn't able to enable the skin for Skada, found the default option to enable it and include the lua file. Was this removed intentionally?
